### PR TITLE
Adds single track support

### DIFF
--- a/lobster/audio.py
+++ b/lobster/audio.py
@@ -35,10 +35,12 @@ def build_time_range(stream_len, streamSegments):
     for idx, stream_segment in enumerate(sortedStreamSegments):
         stream_segment.initial_time = time_to_mil(stream_segment.initial_time)
         if stream_segment.position == 0:
-            stream_segment.initial_time = 0
             if stream_segment.end_time is None:
-                nxt_stream_init_t = sortedStreamSegments[idx + 1].initial_time
-                stream_segment.end_time = time_to_mil(nxt_stream_init_t) - t_separator
+                if len(streamSegments) == 1:
+                    stream_segment.end_time = stream_len - t_separator
+                else:
+                    nxt_stream_init_t = sortedStreamSegments[idx + 1].initial_time
+                    stream_segment.end_time = time_to_mil(nxt_stream_init_t) - t_separator
         elif stream_segment.position < len(streamSegments) - 1:
             if stream_segment.end_time is None:
                 nxt_stream_init_t = sortedStreamSegments[idx + 1].initial_time

--- a/lobster/parser.py
+++ b/lobster/parser.py
@@ -16,7 +16,7 @@ def parse_tracks_file(tracks_file):
                 raise InputFileException('Input File Error: Missing separator'\
                                          + ' in  line {}'.format(str(pos)))
             _d = line.split(separator)
-            validate_line(_d)
+            validate_line(_d, pos)
             stream_segs.append(StreamSegment(name=_d[0], position=pos,
                               initial_time=_d[1], end_time=None))
     return stream_segs


### PR DESCRIPTION
Adds a check in case the first item is the only item (list length == 1), to defined the `end_time` the same way as the last item calculates the end of stream time.

Adress: https://github.com/noahfx/lobster/issues/5