### PR TITLE
Use os path join method for string path building

### DIFF
--- a/lobster/filemanager.py
+++ b/lobster/filemanager.py
@@ -12,7 +12,7 @@ def get_tempdir():
 def get_workingdir():
     tmp_dir = get_tempdir()
     dir_name = str(int(time.time()))
-    path = "/".join([tmp_dir, dir_name])
+    path = os.path.join(tmp_dir, dir_name)
     os.mkdir(path)
     return path
 


### PR DESCRIPTION
Changes string join for `os.path.join`
which is suggested to join/build string paths

Reference:
https://docs.python.org/3/library/os.path.html#os.path.join